### PR TITLE
Fixes to allow compilation with Visual Studio 2015

### DIFF
--- a/cola/libavoid/connend.cpp
+++ b/cola/libavoid/connend.cpp
@@ -26,6 +26,7 @@
 #include <cmath>
 #include <cstdlib>
 #include <cfloat>
+#include <algorithm>
 
 #include "libavoid/router.h"
 #include "libavoid/connend.h"

--- a/cola/libavoid/geomtypes.cpp
+++ b/cola/libavoid/geomtypes.cpp
@@ -26,6 +26,7 @@
 #include <cmath>
 #include <cfloat>
 #include <cstdlib>
+#include <algorithm>
 
 #include "libavoid/geomtypes.h"
 #include "libavoid/shape.h"

--- a/cola/libavoid/junction.cpp
+++ b/cola/libavoid/junction.cpp
@@ -23,6 +23,7 @@
 */
 
 #include <cstdlib>
+#include <algorithm>
 
 #include "libavoid/junction.h"
 #include "libavoid/router.h"

--- a/cola/libavoid/libavoid.vcxproj
+++ b/cola/libavoid/libavoid.vcxproj
@@ -147,6 +147,7 @@
     <ClCompile Include="geomtypes.cpp" />
     <ClCompile Include="graph.cpp" />
     <ClCompile Include="hyperedge.cpp" />
+    <ClCompile Include="hyperedgeimprover.cpp" />
     <ClCompile Include="hyperedgetree.cpp" />
     <ClCompile Include="junction.cpp" />
     <ClCompile Include="makepath.cpp" />
@@ -169,10 +170,12 @@
     <ClInclude Include="connector.h" />
     <ClInclude Include="connend.h" />
     <ClInclude Include="debug.h" />
+    <ClInclude Include="dllexport.h" />
     <ClInclude Include="geometry.h" />
     <ClInclude Include="geomtypes.h" />
     <ClInclude Include="graph.h" />
     <ClInclude Include="hyperedge.h" />
+    <ClInclude Include="hyperedgeimprover.h" />
     <ClInclude Include="hyperedgetree.h" />
     <ClInclude Include="junction.h" />
     <ClInclude Include="libavoid.h" />

--- a/cola/libavoid/scanline.cpp
+++ b/cola/libavoid/scanline.cpp
@@ -23,6 +23,7 @@
 */
 
 #include <cfloat>
+#include <algorithm>
 
 #include "libavoid/scanline.h"
 #include "libavoid/obstacle.h"


### PR DESCRIPTION
I had to include the <algorithm> header in several files for the `min` and `max` functions to be available. The validation if this breaks anything is left to you :).
