### PR TITLE
Fix clang build error

### DIFF
--- a/cola/libvpsc/rectangle.cpp
+++ b/cola/libvpsc/rectangle.cpp
@@ -561,7 +561,7 @@ void Rectangle::routeAround(double x1, double y1, double x2, double y2,
  * @param rs the rectangles which will be moved to remove overlap
  */
 void removeoverlaps(Rectangles& rs) {
-    const set<unsigned> fixed;
+    set<unsigned> fixed;
     removeoverlaps(rs,fixed);
 }
 #define ISNOTNAN(d) (d)==(d)


### PR DESCRIPTION
libvpsc/rectangle.cpp:564:25: error: default initialization of an object of const type 'const set<unsigned int>' without a user-provided default constructor

Indeed, (standard, section 8.5) If a program calls for the default initialization of an object of a const-qualified type T, T shall be a class type with a user-provided default constructor.

(Basically, the standard prevents you from creating a useless unusable object)