### PR TITLE
Add missing cassert include

### DIFF
--- a/cola/libdialect/util.h
+++ b/cola/libdialect/util.h
@@ -25,6 +25,7 @@
 #ifndef DIALECT_UTIL_H
 #define DIALECT_UTIL_H
 
+#include <cassert>
 #include <cmath>
 #include <string>
 #include <memory>


### PR DESCRIPTION
This is required to compile on Arch Linux (gcc 8.2.1).