### PR TITLE
isinf: use C++11 standard library function

### DIFF
--- a/cola/libcola/cola.cpp
+++ b/cola/libcola/cola.cpp
@@ -142,7 +142,7 @@ ConstrainedMajorizationLayout
             Dij[i*n + j] = d;
             if(i==j) continue;
             double lij=0;
-            if(d!=0 && !isinf(d)) {
+            if(d!=0 && !std::isinf(d)) {
                 lij=1./(d*d);
             }
             degree += lap2[i*n + j] = lij;
@@ -300,7 +300,7 @@ inline double ConstrainedMajorizationLayout
     for (unsigned i = 1; i < n; i++) {
         for (unsigned j = 0; j < i; j++) {
             d = Dij[i*n+j];
-            if(!isinf(d)&&d!=numeric_limits<double>::max()) {
+            if(!std::isinf(d)&&d!=numeric_limits<double>::max()) {
                 diff = d - euclidean_distance(i,j);
                 if(d>80&&diff<0) continue;
                 sum += diff*diff / (d*d);

--- a/cola/libcola/commondefs.h
+++ b/cola/libcola/commondefs.h
@@ -32,7 +32,7 @@
 #include <malloc.h>     // Contains _alloca
 namespace std {
 inline bool isnan(double const &x) { return _isnan(x) != 0; }
-inline bool isinf(double const &x) { return !(_finite(x) || _isnan(x)); }
+inline bool std::isinf(double const &x) { return !(_finite(x) || _isnan(x)); }
 } // end std
 
 #endif


### PR DESCRIPTION
`isinf` causes issues when compiling on Ubuntu Trusty, see
* https://gitlab.com/inkscape/inkscape/commit/b82b890314bfc64364f38e69696f7c6596ec3536
* https://gitlab.com/inkscape/inkscape/commit/2d607cec2e3a62427e6c6beb4f3e3c28e3770ac6 