### PR TITLE
Fix compile warnings when _USE_MATH_DEFINES is defined globally

### DIFF
--- a/cola/libavoid/geometry.cpp
+++ b/cola/libavoid/geometry.cpp
@@ -34,7 +34,9 @@
 
 
 // For M_PI:
+#ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
+#endif
 #include <cmath>
 
 #include <limits>

--- a/cola/libavoid/makepath.cpp
+++ b/cola/libavoid/makepath.cpp
@@ -24,7 +24,9 @@
 
 // For M_PI.
 // This should be first include for MSVC.
+#ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
+#endif
 #include <cmath>
 
 #include <algorithm>

--- a/cola/libcola/tests/convex_hull.cpp
+++ b/cola/libcola/tests/convex_hull.cpp
@@ -39,7 +39,9 @@
 
 /* M_PI is defined in math.h in the case of Microsoft Visual C++ */
 #if defined(_MSC_VER)
+#ifndef _USE_MATH_DEFINES
 #define _USE_MATH_DEFINES
+#endif
 #include <math.h>
 #endif 
 using namespace std;


### PR DESCRIPTION
I.e. when we set _USE_MATH_DEFINES via compiler flags, then the
compiler would warn that _USE_MATH_DEFINES is getting redefined.