### PR TITLE
Add limits for libdialect

### DIFF
--- a/cola/libdialect/util.h
+++ b/cola/libdialect/util.h
@@ -28,6 +28,7 @@
 #include <cassert>
 #include <cmath>
 #include <string>
+#include <limits>
 #include <memory>
 #include <cstdio>
 #include <map>


### PR DESCRIPTION
I ran into a compilation issue when I built adaptagrams on Fedora 34.

```
../libdialect/util.h: In function ‘bool dialect::logically_equal(double, double, double)’:
../libdialect/util.h:50:65: error: ‘numeric_limits’ is not a member of ‘std’
   50 |     return a==b || std::abs(a-b) < std::abs(std::min(a,b))*std::numeric_limits<double>::epsilon()*error_factor;
      |                                                                 ^~~~~~~~~~~~~~
```

By adding an include of `<limits>` to `cola/libdialect/util.h`, the build succeeded.
