### PR TITLE
Add nudging distance setting to `HolaOpts`

### DIFF
--- a/cola/libdialect/hola.cpp
+++ b/cola/libdialect/hola.cpp
@@ -401,6 +401,7 @@ void dialect::doHOLA(Graph &G, const HolaOpts &holaOpts, Logger *logger) {
     ra.router.setRoutingOption(Avoid::nudgeSharedPathsWithCommonEndPoint, true);
     ra.router.setRoutingParameter(Avoid::crossingPenalty, 2*IEL);
     ra.router.setRoutingParameter(Avoid::segmentPenalty, IEL/2.0);
+    ra.router.setRoutingParameter(Avoid::idealNudgingDistance, holaOpts.routingAbs_nudgingDistance);
     // Ask the core graph to add its nodes, and just those edges that do not have any bend nodes.
     // After asking G to clear all routes (remember G has the same Edges as core), these will be all and only
     // those Edges for which no Chain set any aesthetic bend.

--- a/cola/libdialect/opts.h
+++ b/cola/libdialect/opts.h
@@ -113,6 +113,8 @@ struct HolaOpts {
     //! a scalar, set here.
     double routingScalar_crossingPenalty = 2;
     double routingScalar_segmentPenalty = 0.5;
+    //! Other routing parameters take an absolute value.
+    double routingAbs_nudgingDistance = 4.0;
 
 
     //! Tree Placement

--- a/cola/libdialect/tests/Makefile.am
+++ b/cola/libdialect/tests/Makefile.am
@@ -7,7 +7,7 @@ LDADD = \
   $(top_builddir)/libdialect/libdialect.la
 
 # Basic unit testing:
-check_PROGRAMS = aca assignments bbox bendcosts chainconfig01 chainconfig02 chainconfig03 chainsandcycles cmplayout01 collateralexpand01 collateralexpand02 conncomps containedsegment01 destress destress02 destress_aca expand01 expand02 expand03 expand04 expand05 expand06 expand07 expand08 expand09 extrabdrygap faceset01 faceset02 hola10 hola11 hola12 holalonenode inserttrees01 leaflessroute01 leaflessroute02 lookupqas nbroctal nearalign01 nearalign02 nearby negativesepco negativezero nodeconfig01 partition01 peel planarise01 planarise02 projseq01 readconstraints rotate01 rotate02 rotate03 rotate04 routing01 solidify symmtree tglf01 treeboxes01 treeplacement01 treeplacement02 treeplacement03 trees trees2 vpsc01
+check_PROGRAMS = aca assignments bbox bendcosts chainconfig01 chainconfig02 chainconfig03 chainsandcycles cmplayout01 collateralexpand01 collateralexpand02 conncomps containedsegment01 destress destress02 destress_aca expand01 expand02 expand03 expand04 expand05 expand06 expand07 expand08 expand09 extrabdrygap faceset01 faceset02 hola10 hola11 hola12 holalonenode inserttrees01 leaflessroute01 leaflessroute02 lookupqas nbroctal nearalign01 nearalign02 nearby negativesepco negativezero nodeconfig01 nudgeopt partition01 peel planarise01 planarise02 projseq01 readconstraints rotate01 rotate02 rotate03 rotate04 routing01 solidify symmtree tglf01 treeboxes01 treeplacement01 treeplacement02 treeplacement03 trees trees2 vpsc01
 
 # Test HOLA on some larger and more interesting SBGN and metro map diagrams:
 # Takes a few minutes.
@@ -62,6 +62,7 @@ nearby_SOURCES = nearby.cpp
 negativesepco_SOURCES = negativesepco.cpp
 negativezero_SOURCES = negativezero.cpp
 nodeconfig01_SOURCES = nodeconfig01.cpp
+nudgeopt_SOURCES = nudgeopt.cpp
 partition01_SOURCES = partition01.cpp
 peel_SOURCES = peel.cpp
 planarise01_SOURCES = planarise01.cpp

--- a/cola/libdialect/tests/nudgeopt.cpp
+++ b/cola/libdialect/tests/nudgeopt.cpp
@@ -1,0 +1,105 @@
+/*
+ * vim: ts=4 sw=4 et tw=0 wm=0
+ *
+ * libdialect - A library for computing DiAlEcT layouts:
+ *                 D = Decompose/Distribute
+ *                 A = Arrange
+ *                 E = Expand/Emend
+ *                 T = Transform
+ *
+ * Copyright (C) 2023  Monash University
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * See the file LICENSE.LGPL distributed with the library.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Author(s):   Steve Kieffer   <http://skieffer.info>
+*/
+
+#include <iostream>
+
+#include "libavoid/geomtypes.h"
+
+#include "libdialect/commontypes.h"
+#include "libdialect/io.h"
+#include "libdialect/util.h"
+#include "libdialect/graphs.h"
+#include "libdialect/opts.h"
+#include "libdialect/hola.h"
+
+using std::vector;
+using Avoid::Point;
+
+using namespace dialect;
+
+/* In the HOLA layout we compute for the graph "graphs/random/v10e10.tglf", the
+ * three directed edges (1, 0), (4, 1), (7, 1) will all leave node 1 on the same
+ * side, and libavoid nudging will be employed to separate them.
+ * 
+ * This function returns a vector of three doubles, being the y-coords of the route
+ * points on these three edges, representing their connection to node 1. The difference
+ * between adjacent pairs of these coordinates should equal the nuding distance set in
+ * the HolaOpts.
+ */
+vector<double> checkYCoords(Graph_SP graph) {
+    EdgesById edges = graph->getEdgeLookup();
+
+    Edge_SP e10, e41, e71;
+    for (auto p : edges) {
+        Edge_SP e = p.second;
+        unsigned s = e->getSourceEnd()->getExternalId();
+        unsigned t = e->getTargetEnd()->getExternalId();
+        if (s == 1 && t == 0) {
+            e10 = e;
+        } else if (s == 4 && t == 1) {
+            e41 = e;
+        } else if (s == 7 && t == 1) {
+            e71 = e;
+        }
+    }
+    
+    vector<Point> e10Route = e10->getRoute();
+    vector<Point> e41Route = e41->getRoute();
+    vector<Point> e71Route = e71->getRoute();
+    
+    Point a = e41Route.at(e41Route.size() - 1);
+    Point b = e10Route.at(0);
+    Point c = e71Route.at(e71Route.size() - 1);
+
+    std::cout << a.x << ", " << a.y << std::endl;
+    std::cout << b.x << ", " << b.y << std::endl;
+    std::cout << c.x << ", " << c.y << std::endl;
+
+    vector<double> coords = {a.y, b.y, c.y};
+    return coords;
+}
+
+int main(void) {
+
+    std::string name = "graphs/random/v10e10.tglf";
+
+    // Layout with default nudging distance of 4.0 pixels:
+    HolaOpts opts;
+    Graph_SP graph = buildGraphFromTglfFile(name);
+    doHOLA(*graph, opts);
+    vector<double> coords = checkYCoords(graph);
+    COLA_ASSERT(coords[1] - coords[0] == 4.0);
+    COLA_ASSERT(coords[2] - coords[1] == 4.0);
+    writeStringToFile(graph->writeTglf(), "output/" "nudgeopt_4.tglf");
+
+    // Repeat same layout, but now with nudging distance set to 5.0 pixels:
+    opts.routingAbs_nudgingDistance = 5.0;
+    graph = buildGraphFromTglfFile(name);
+    doHOLA(*graph, opts);
+    coords = checkYCoords(graph);
+    COLA_ASSERT(coords[1] - coords[0] == 5.0);
+    COLA_ASSERT(coords[2] - coords[1] == 5.0);
+    writeStringToFile(graph->writeTglf(), "output/" "nudgeopt_5.tglf");
+    
+}


### PR DESCRIPTION
This makes it possible to set the `libavoid` nudging distance that will be used by HOLA, in its final edge routing step.