### PR TITLE
Repair `EdgePoint` pruning in `libtopology`

### DIFF
--- a/cola/libtopology/topology_graph.cpp
+++ b/cola/libtopology/topology_graph.cpp
@@ -126,6 +126,12 @@ bool EdgePoint::createBendConstraint(vpsc::Dim scanDim) {
     if(isEnd()) {
         return false;
     }
+    // don't try to generate a BendConstraint if both incident segments
+    // are parallel to the scan dimension
+    if(inSegment->length(vpsc::conjugate(scanDim)) == 0 &&
+       outSegment->length(vpsc::conjugate(scanDim)) == 0) {
+        return false;
+    }
     bendConstraint = new BendConstraint(this, scanDim);
     return true;
 }


### PR DESCRIPTION
Abstract
======

The test `libtopology/tests/beautify` sometimes fails, depending on where the test is running, due to differences in random number generation.

When it does fail, the core issue seems to be in how we prune degenerate `EdgePoint`s when generating the topology-preserving constraints. This patch corrects the pruning process.


Full Discussion
===========

This patches an issue that can arise in the test, `libtopology/tests/beautify`.


Random seed, and triggering the issue
-------------------------------------

The issue can be tricky to trigger, because the `beautify` test generates a random graph, and, although it uses a fixed seed, the results seem to depend on the platform where the test is running -- perhaps some combination of the compiler, the OS, etc.

With the current seed value, `1207906420`, I get no issue on my MacBook, which uses

    Apple LLVM version 10.0.1 (clang-1001.0.46.4)

However, the same seed value leads to a failure on the GitHub Ubuntu-22.04 test runner, which appears to be using

    g++ (Ubuntu 11.3.0-1ubuntu1~22.04.1) 11.3.0

I debugged the issue on my MacBook by incrementing the seed to `1207906421`, which resulted in a large graph that triggered the problem.


The issue itself
----------------

When we construct `TopologyConstraints`, we prune degenerate `EdgePoint` s:

https://github.com/mjwybrow/adaptagrams/blob/fcac991f9f7d959e8326ae0567ce122839fbd4be/cola/libtopology/topology_constraints_constructor.cpp#L692-L699

Basically, an `EdgePoint` is degenerate when there is no actual bend there. In such a case, we want to delete the point, and replace its incoming and outgoing segments with one long segment.

The `EdgePoint.prune()` method is defined here:

https://github.com/mjwybrow/adaptagrams/blob/fcac991f9f7d959e8326ae0567ce122839fbd4be/cola/libtopology/topology_graph.cpp#L83-L116

However, a problem can arise when an edge contains 4 or more consecutive edge points, all of which are collinear, meaning that all of the internal ones (at least two) need to be pruned. Then this line,

https://github.com/mjwybrow/adaptagrams/blob/fcac991f9f7d959e8326ae0567ce122839fbd4be/cola/libtopology/topology_graph.cpp#L109

can try to create a bend constraint where there is no bend, and we get a crash here

https://github.com/mjwybrow/adaptagrams/blob/fcac991f9f7d959e8326ae0567ce122839fbd4be/cola/libtopology/topology_graph.h#L325

because the denominator actually is zero.


Example
-------

On my MacBook, with the incremented seed `1207906421`, I got this example:

```
             [144    174|174    204|204    234|234    264|264    294]

        325                                   +----------+----------+
        330  +----------+----------+----------+    41    |    40    |
        335  |    90    |    88    |    89    +----------+----------+
        340  +----------+----------+----------+

edge 89:
     P       Q        R        S        T        U
    41C --> 89BR --> 89BL --> 88BR --> 88BL --> 90C

                                              +----------+----------+
             +----------T---------S+R---------Q    P     |          |
             |    U     |          |          +----------+----------+
             +----------+----------+----------+
```

Nodes 90, 88, 89, 41, and 40 are abutting in the x-dimension. Nodes 90, 88, and 89 are aligned in the y-dimension, etc.
(IN FACT, the nodes are not quite abutting. Their near x-coords actually differ by `0.00002`.)

The edge where the problem arises is described in the figure above as well. It runs from the center of node 41, to the bottom right corner of node 89, etc., ending at center of node 90. Note that, since y-coords increase downward, "bottom right" means the NE corner of the node in the diagram above.

The first 5 points on this edge (`P, Q, R, S, T`) are all aligned on a horizontal line. Therefore the middle three, `Q, R, S`, all need to be pruned.

The crash comes when we try to prune the first of these, `Q`. We delete point `Q`, and replace the two horizontal segments `PQ` and `QR` with a new, longer segment `PR`. This is fine. But then we ask to form a `BendConstraint` at the endpoint `R` of this new segment, and it crashes, since the new sequence `P, R, S` is again totally horizontal.


Solution
--------

This patch makes `EdgePoint::createBendConstraint()` simply do nothing in the problematic case. So, when we get to `P, R, S` in the example above, it sees that segments `PR` and `RS` are both horizontal, and it gives up on generating a `BendConstraint`.

This means we're able to keep pruning, until finally we're down to `P, T, U` as the only points left on the edge. Here, we finally *do* generate a `BendConstraint` at `T`, because there actually is a bend there.


Bottom line
-----------

This patch only adds four lines of code, and the easiest way to understand them is to compare them to the `BendConstraint` constructor, specifically, the ending:

https://github.com/mjwybrow/adaptagrams/blob/fcac991f9f7d959e8326ae0567ce122839fbd4be/cola/libtopology/topology_constraints_constructor.cpp#L479-L489

This ending is ultimately going to call [the `Segment::intersection()` method](https://github.com/mjwybrow/adaptagrams/blob/fcac991f9f7d959e8326ae0567ce122839fbd4be/cola/libtopology/topology_graph.h#L317) (via `forwardIntersection` or `reverseIntersection`) on one of the two incident segments, `inSegment` or `outSegment`. Whichever segment it chooses has to have non-zero length in the conjugate dimension. The four lines of this patch simply say: "If both of those lengths are zero, then don't try to construct a `BendConstraint`!"