### PR TITLE
Apply nudging distance HOLA opt when graph is tree

### DIFF
--- a/cola/libdialect/hola.cpp
+++ b/cola/libdialect/hola.cpp
@@ -107,6 +107,7 @@ void dialect::doHOLA(Graph &G, const HolaOpts &holaOpts, Logger *logger) {
         RoutingAdapter ra(Avoid::OrthogonalRouting);
         ra.router.setRoutingOption(Avoid::nudgeOrthogonalSegmentsConnectedToShapes, true);
         ra.router.setRoutingOption(Avoid::nudgeSharedPathsWithCommonEndPoint, true);
+        ra.router.setRoutingParameter(Avoid::idealNudgingDistance, holaOpts.routingAbs_nudgingDistance);
         tree->addNetworkToRoutingAdapter(ra, holaOpts.wholeTreeRouting);
         ra.route();
         // Remove node padding.

--- a/cola/libdialect/tests/Makefile.am
+++ b/cola/libdialect/tests/Makefile.am
@@ -14,7 +14,7 @@ check_PROGRAMS = \
   expand01 expand02 expand03 expand04 expand05 expand06 expand07 expand08 expand09 \
   extrabdrygap faceset01 faceset02 hola10 hola11 hola12 \
   hola_arpa hola_belnet hola_cernet hola_claranet hola_garr hola_janetlense hola_slovakia \
-  holalonenode inserttrees01 leaflessroute01 leaflessroute02 lookupqas nbroctal \
+  holalonenode hola_tree inserttrees01 leaflessroute01 leaflessroute02 lookupqas nbroctal \
   nearalign01 nearalign02 nearby negativesepco negativezero nodeconfig01 nudgeopt \
   partition01 peel planarise01 planarise02 projseq01 readconstraints \
   rotate01 rotate02 rotate03 rotate04 routing01 sep_matrix_iter solidify symmtree \
@@ -69,6 +69,7 @@ hola_garr_SOURCES = hola_garr.cpp
 hola_janetlense_SOURCES = hola_janetlense.cpp
 hola_slovakia_SOURCES = hola_slovakia.cpp
 holalonenode_SOURCES = holalonenode.cpp
+hola_tree_SOURCES = hola_tree.cpp
 inserttrees01_SOURCES = inserttrees01.cpp
 leaflessroute01_SOURCES = leaflessroute01.cpp
 leaflessroute02_SOURCES = leaflessroute02.cpp

--- a/cola/libdialect/tests/hola_tree.cpp
+++ b/cola/libdialect/tests/hola_tree.cpp
@@ -1,0 +1,45 @@
+/*
+ * vim: ts=4 sw=4 et tw=0 wm=0
+ *
+ * libdialect - A library for computing DiAlEcT layouts:
+ *                 D = Decompose/Distribute
+ *                 A = Arrange
+ *                 E = Expand/Emend
+ *                 T = Transform
+ *
+ * Copyright (C) 2018  Monash University
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ * See the file LICENSE.LGPL distributed with the library.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *
+ * Author(s):   Steve Kieffer   <http://skieffer.info>
+*/
+
+#include "libdialect/commontypes.h"
+#include "libdialect/io.h"
+#include "libdialect/util.h"
+#include "libdialect/graphs.h"
+#include "libdialect/opts.h"
+#include "libdialect/logging.h"
+#include "libdialect/hola.h"
+
+using namespace dialect;
+
+int main(void) {
+    Graph_SP graph = buildGraphFromTglfFile("graphs/" "trees/tree02.tglf");
+    HolaOpts opts;
+    //opts.routingAbs_nudgingDistance = 10;
+    std::string prefix = "hola_tree02_";
+    bool debug = false;
+    if (debug) doHOLA(*graph, opts, new Logger("output/", prefix, true, true));
+    else doHOLA(*graph, opts);
+    writeStringToFile(graph->writeTglf(), "output/" + prefix + "layout.tglf");
+    writeStringToFile(graph->writeSvg(), "output/" "svg/" + prefix + "layout.svg");
+}


### PR DESCRIPTION
In #56 we added an option to set the connector nudging distance for the final routing step in HOLA; however, the case of a pure tree graph was accidentally omitted. This includes it.