### PR TITLE
Fix warning: catching polymorphic type 'class std::runtime_error' by value [-Wcatch-value=]

### DIFF
--- a/cola/libtopology/topology_graph.cpp
+++ b/cola/libtopology/topology_graph.cpp
@@ -295,7 +295,7 @@ bool EdgePoint::assertConvexBend() const {
                         COLA_ASSERT(false);
                 }
             }
-        } catch(runtime_error e) {
+        } catch(runtime_error & e) {
             printf("  convexity bend point test failed: %s, dx=%f, dy=%f, cp=%f:\n",e.what(),dx,dy,cp);
             printf("    (nid=%d,ri=%d):u={%f,%f}\n",
                     u->node->id,u->rectIntersect,u->posX(),u->posY());


### PR DESCRIPTION
```
|| topology_graph.cpp: In member function 'bool topology::EdgePoint::assertConvexBend() const':
libtopology/./topology_graph.cpp|298 col 31| warning: catching polymorphic type 'class std::runtime_error' by value [-Wcatch-value=]
||   298 |         } catch(runtime_error e) {
||       |                               ^
```