### PR TITLE
Fixed error in VertID that broke windows release build

### DIFF
--- a/cola/libavoid/vertices.h
+++ b/cola/libavoid/vertices.h
@@ -48,7 +48,7 @@ typedef unsigned int ConnDirFlags;
 typedef unsigned short VertIDProps;
 
 
-class VertID
+class AVOID_EXPORT VertID
 {
     public:
         unsigned int objID;

--- a/cola/libavoid/vpsc.cpp
+++ b/cola/libavoid/vpsc.cpp
@@ -480,11 +480,6 @@ Constraint* IncSolver::mostViolated(Constraints &l)
 }
 
 
-using std::set;
-using std::vector;
-using std::iterator;
-using std::list;
-using std::copy;
 #define __NOTNAN(p) (p)==(p)
 
 


### PR DESCRIPTION
The windows build had a linking error that some VertID symbols weren't being defined.  This resolves that error.  Also, inclusion of std::iterator in vspc.cpp was giving a deprecation warning on later versions of visual studio. 