### PR TITLE
Fix issues with newer versions of g++, fix swig issues, fix svg output

### DIFF
--- a/cola/Makefile-swig-java
+++ b/cola/Makefile-swig-java
@@ -2,21 +2,38 @@ OSNAME:=$(shell uname -s | sed 's/_.*//')
 
 ifeq ($(OSNAME),Darwin)
 	CPPFLAGS =
-	JAVA_INCLUDE = -I/System/Library/Frameworks/JavaVM.framework/Headers
-	LINK = $(CXX) $(CXXFLAGS) -dynamiclib -framework JavaVM -o adaptagrams.dylib
+	CXXFLAGS += -std=c++11
+	# Change path to JDK
+	# JAVA_INCLUDE = -I/System/Library/Frameworks/JavaVM.framework/Headers
+	JAVA_INCLUDE = -I/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home/include \
+					-I/Library/Java/JavaVirtualMachines/temurin-8.jdk/Contents/Home/include/darwin
+	# LINK = $(CXX) $(CXXFLAGS) -dynamiclib -framework JavaVM -o adaptagrams.dylib
+	LINK = $(CXX) $(CXXFLAGS) -dynamiclib -o adaptagrams.dylib
 else 
 	# Some make versions say only one else per if statment.
 	ifeq ($(OSNAME),Linux)
 		CPPFLAGS = -fPIC
-		JAVA_INCLUDE = -I/usr/lib/jvm/java-6-sun/include \
-						-I/usr/lib/jvm/java-6-sun/include/linux
+		# Change path to JDK
+		JAVA_INCLUDE = -I/usr/lib/jvm/java-8-openjdk-amd64/include \
+						-I/usr/lib/jvm/java-8-openjdk-amd64/include/linux
 		LINK = $(CXX) $(CXXFLAGS) -shared -o adaptagrams.so
 	else 
-	    ifeq ($(OSNAME),MINGW32)
+		ifeq ($(OSNAME),MINGW32)
 			CPPFLAGS =
-			JAVA_INCLUDE = -I/c/Programme/Java/jdk1.6.0_24/include \
-							-I/c/Programme/Java/jdk1.6.0_24/include/win32
+			# Change path to JDK
+			JAVA_INCLUDE = -I"/c/Program Files/Java/jdk-1.8/include" \
+							-I"/c/Program File/Java/jdk-1.8/include/win32"
+			# Building with MinGW
 			LINK = $(CXX) $(CXXFLAGS) -Wl,--add-stdcall-alias -shared -o adaptagrams.dll
+		else
+			ifeq ($(OSNAME),MINGW64)
+				CPPFLAGS =
+				# Change path to JDK
+				JAVA_INCLUDE = -I"/c/Program Files/Java/jdk-1.8/include" \
+								-I"/c/Program Files/Java/jdk-1.8/include/win32"
+				# Building with MSYS2
+				LINK = $(CXX) $(CXXFLAGS) -Wl,--add-stdcall-alias -static-libgcc -static-libstdc++ -static -lpthread -shared -o adaptagrams.dll
+			endif
 		endif
 	endif
 endif
@@ -26,6 +43,7 @@ all: adaptagrams jar
 swig-worked: clean adaptagrams.i
 	mkdir -p java/src/org/adaptagrams
 	mkdir -p java/build/org/adaptagrams
+	# Use Swig version 3
 	swig -DUSE_ASSERT_EXCEPTIONS -c++ -java -package org.adaptagrams -outdir java/src/org/adaptagrams adaptagrams.i
 	touch swig-worked
 

--- a/cola/adaptagrams.i
+++ b/cola/adaptagrams.i
@@ -118,6 +118,12 @@ using namespace dialect;
 %ignore dialect::identifyRootNode(const Graph&);
 %ignore dialect::negateSepDir(SepDir);
 %ignore dialect::swap(Graph&, Graph&);
+%ignore dialect::ProjSeq::operator+=(const ProjSeq&);
+%ignore dialect::BoundingBox::operator+=(const BoundingBox&);
+%ignore dialect::NodeIdCmp::operator()(id_type, const std::pair<id_type, Node_SP>&) const;
+%ignore dialect::NodeIdCmp::operator()(const std::pair<id_type, Node_SP>&, id_type) const;
+%ignore dialect::operator&(AlignmentFlag, AlignmentFlag);
+%ignore dialect::operator|=(AlignmentFlag&, AlignmentFlag);
 
 %include "std_string.i"
 %include "std_vector.i"
@@ -261,6 +267,11 @@ void deleteDoubleArray(double* a) {
 
 %rename(DialectNode) dialect::Node;
 %rename(DialectEdge) dialect::Edge;
+
+%rename(X1) dialect::BoundingBox::x;
+%rename(Y1) dialect::BoundingBox::y;
+%rename(X2) dialect::BoundingBox::X;
+%rename(Y2) dialect::BoundingBox::Y;
 
 %shared_ptr(dialect::Node)
 %shared_ptr(dialect::GhostNode)

--- a/cola/autogen.sh
+++ b/cola/autogen.sh
@@ -20,6 +20,8 @@ autoreconf --install --verbose
 
 # Configure.
 ./configure
+# Compile with CXXFLAGS="-std=c++11" when using MSYS2 and g++ 14 or newer
+# ./configure CXXFLAGS="-std=c++11"
 
 # Instead, use this line if building for SWIG Java:
 # ./configure CPPFLAGS="-DUSE_ASSERT_EXCEPTIONS"

--- a/cola/autogen.sh
+++ b/cola/autogen.sh
@@ -20,11 +20,13 @@ autoreconf --install --verbose
 
 # Configure.
 ./configure
-# Compile with CXXFLAGS="-std=c++11" when using MSYS2 and g++ 14 or newer
+# Compile with CXXFLAGS="-std=c++11" when using g++ 14 or newer
 # ./configure CXXFLAGS="-std=c++11"
 
 # Instead, use this line if building for SWIG Java:
 # ./configure CPPFLAGS="-DUSE_ASSERT_EXCEPTIONS"
+# Compile with CXXFLAGS="-std=c++11" when using g++ 14 or newer
+# ./configure CXXFLAGS="-std=c++11" CPPFLAGS="-DUSE_ASSERT_EXCEPTIONS"
 
 # Instead, use this line if building for SWIG Python:
 # ./configure CXXFLAGS="-O3 -DNDEBUG -arch x86_64 -arch i386" LDFLAGS="-arch x86_64 -arch i386"

--- a/cola/libavoid/router.cpp
+++ b/cola/libavoid/router.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cfloat>
+#include <clocale>
 
 #include "libavoid/shape.h"
 #include "libavoid/router.h"
@@ -2357,6 +2358,11 @@ void Router::improveOrthogonalTopology(void)
 
 void Router::outputInstanceToSVG(std::string instanceName)
 {
+    // Save current locale
+    char* originalLocale = setlocale(LC_NUMERIC, nullptr);
+    // Set locale to "C" to enforce decimal point
+    setlocale(LC_NUMERIC, "C");
+
     std::string filename;
     if (!instanceName.empty())
     {
@@ -2856,6 +2862,8 @@ void Router::outputInstanceToSVG(std::string instanceName)
     fprintf(fp, "</svg>\n");
     fclose(fp);
     //printInfo();
+    // Restore locale
+    setlocale(LC_NUMERIC, originalLocale);
 }
 
 void Router::outputDiagramSVG(std::string instanceName, LineReps *lineReps)

--- a/cola/libcola/colafd.cpp
+++ b/cola/libcola/colafd.cpp
@@ -1625,13 +1625,13 @@ ProjectionResult solve(Variables &vs, Constraints &cs, Rectangles &rs, unsigned 
                 sprintf(buf, "v_%d\n", c->right->id);
                 unsatinfo += buf;
                 if ((unsigned) c->left->id < rs.size()) {
-                    Rectangle *r = rs[c->left->id];
+                    vpsc::Rectangle *r = rs[c->left->id];
                     sprintf(buf, "    v_%d rect: [%f, %f] x [%f, %f]\n", c->left->id,
                             r->getMinX(), r->getMaxX(), r->getMinY(), r->getMaxY());
                     unsatinfo += buf;
                 }
                 if ((unsigned) c->right->id < rs.size()) {
-                    Rectangle *r = rs[c->right->id];
+                    vpsc::Rectangle *r = rs[c->right->id];
                     sprintf(buf, "    v_%d rect: [%f, %f] x [%f, %f]\n", c->right->id,
                             r->getMinX(), r->getMaxX(), r->getMinY(), r->getMaxY());
                     unsatinfo += buf;
@@ -1655,13 +1655,13 @@ ProjectionResult solve(Variables &vs, Constraints &cs, Rectangles &rs, unsigned 
                     sprintf(buf, "v_%d\n", c->right->id);
                     unsatinfo += buf;
                     if ((unsigned) c->left->id < rs.size()) {
-                        Rectangle *r = rs[c->left->id];
+                        vpsc::Rectangle *r = rs[c->left->id];
                         sprintf(buf, "    v_%d rect: [%f, %f] x [%f, %f]\n", c->left->id,
                                 r->getMinX(), r->getMaxX(), r->getMinY(), r->getMaxY());
                         unsatinfo += buf;
                     }
                     if ((unsigned) c->right->id < rs.size()) {
-                        Rectangle *r = rs[c->right->id];
+                        vpsc::Rectangle *r = rs[c->right->id];
                         sprintf(buf, "    v_%d rect: [%f, %f] x [%f, %f]\n", c->right->id,
                                 r->getMinX(), r->getMaxX(), r->getMinY(), r->getMaxY());
                         unsatinfo += buf;

--- a/cola/libcola/colafd.cpp
+++ b/cola/libcola/colafd.cpp
@@ -27,6 +27,7 @@
 #include <vector>
 #include <cmath>
 #include <limits>
+#include <clocale>
 
 #include "libvpsc/solve_VPSC.h"
 #include "libvpsc/variable.h"
@@ -1368,6 +1369,11 @@ static void reduceRange(double& val)
 
 void ConstrainedFDLayout::outputInstanceToSVG(std::string instanceName)
 {
+    // Save current locale
+    char* originalLocale = setlocale(LC_NUMERIC, nullptr);
+    // Set locale to "C" to enforce decimal point
+    setlocale(LC_NUMERIC, "C");
+
     std::string filename;
     if (!instanceName.empty())
     {
@@ -1542,6 +1548,8 @@ void ConstrainedFDLayout::outputInstanceToSVG(std::string instanceName)
 
     fprintf(fp, "</svg>\n");
     fclose(fp);
+    // Restore locale
+    setlocale(LC_NUMERIC, originalLocale);
 }
 
 ProjectionResult projectOntoCCs(Dim dim, Rectangles &rs, CompoundConstraints ccs,

--- a/cola/libdialect/aca.cpp
+++ b/cola/libdialect/aca.cpp
@@ -31,6 +31,7 @@
 
 #include <sstream>
 #include <iostream>
+#include <clocale>
 
 #include "libvpsc/constraint.h"
 #include "libvpsc/variable.h"
@@ -1676,6 +1677,11 @@ static void reduceRange(double& val)
 
 void ACALayout::outputInstanceToSVG(std::string instanceName)
 {
+    // Save current locale
+    char* originalLocale = setlocale(LC_NUMERIC, nullptr);
+    // Set locale to "C" to enforce decimal point
+    setlocale(LC_NUMERIC, "C");
+
     std::string filename;
     if (!instanceName.empty())
     {
@@ -1990,6 +1996,8 @@ void ACALayout::outputInstanceToSVG(std::string instanceName)
 
     fprintf(fp, "</svg>\n");
     fclose(fp);
+    // Restore locale
+    setlocale(LC_NUMERIC, originalLocale);
 }
 
 } // namespace dialect

--- a/cola/libdialect/tests/faceset01.cpp
+++ b/cola/libdialect/tests/faceset01.cpp
@@ -87,8 +87,8 @@ int main(void) {
     // Check external face.
     for (size_t i = 0; i < 7; ++i) {
         Face_SP F = faces[i];
-        if (i == 1) COLA_ASSERT(F->isExternal());
-        else COLA_ASSERT(!F->isExternal());
+        if (i == 1) { COLA_ASSERT(F->isExternal()); }
+        else { COLA_ASSERT(!F->isExternal()); }
     }
 
     // Look at the Sides and Nexes for the concave face #3:

--- a/cola/libtopology/cola_topology_addon.cpp
+++ b/cola/libtopology/cola_topology_addon.cpp
@@ -18,6 +18,11 @@
  * Author(s):  Michael Wybrow
 */
 
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
+#endif
+#include <cmath>
+
 #include <utility>
 
 #include "libvpsc/rectangle.h"

--- a/cola/libtopology/cola_topology_addon.cpp
+++ b/cola/libtopology/cola_topology_addon.cpp
@@ -24,6 +24,7 @@
 #include <cmath>
 
 #include <utility>
+#include <clocale>
 
 #include "libvpsc/rectangle.h"
 #include "libvpsc/constraint.h"
@@ -135,6 +136,11 @@ static void reduceRange(double& val)
 
 void ColaTopologyAddon::writeSVGFile(std::string basename)
 {
+    // Save current locale
+    char* originalLocale = setlocale(LC_NUMERIC, nullptr);
+    // Set locale to "C" to enforce decimal point
+    setlocale(LC_NUMERIC, "C");
+
     std::string filename;
     if (!basename.empty())
     {
@@ -290,6 +296,8 @@ void ColaTopologyAddon::writeSVGFile(std::string basename)
 
     fprintf(fp, "</svg>\n");
     fclose(fp);
+    // Restore locale
+    setlocale(LC_NUMERIC, originalLocale);
 }
 
 double ColaTopologyAddon::computeStress(void) const


### PR DESCRIPTION
This pull request fixes several issues.

- fixes an issue with MSYS2 and g++ 15.1.0: error: 'memset' was not declared in this scope
- fixes an issue in libcola/colafd.cpp: error: 'r' was not declared in this scope
- fixes an issue in libtopology/cola_topology_addon.cpp: error: 'M_PI' was not declared in this scope

- fixes an error in libdialect/tests/faceset01.cpp: error: 'else' without a previous 'if'
- fixes several warnings from libdialect when running swig: Warning 503: Can't wrap 'operator ...' unless renamed to a valid identifier.
- fixes several errors from libdialect when running javac: error: method set...(double)/get...(double) is already defined in class BoundingBox

- The svg output cannot be used when the current locale uses a comma instead of a decimal point.
- Make sure that always locale "C" is used to enforce the decimal point.