### PR TITLE
Fix swig issues with Python build, update files for Python build

### DIFF
--- a/cola/Makefile-swig-python
+++ b/cola/Makefile-swig-python
@@ -4,7 +4,7 @@ COMPILER =
 # to get a list of available compilers run
 # python swig-python-setup.py build_ext --help-compiler
 # no changes necessary on Linux and MacOS
-# change compiler to mingw32 on MinGW
+# change compiler to mingw32 on MinGW (but not on MSYS2)
 ifeq ($(OSNAME),MINGW32)
 	COMPILER = --compiler=mingw32
 endif
@@ -12,10 +12,12 @@ endif
 all: adaptagrams
 
 adaptagrams_wrap.cxx: clean adaptagrams.i
+	# use Swig version 3
 	swig -DNDEBUG -c++ -python adaptagrams.i
 
 adaptagrams: adaptagrams_wrap.cxx
-	python swig-python-setup.py build_ext --inplace $(COMPILER)
+	# change to 'python' on Windows
+	python3 swig-python3-setup.py build_ext --inplace $(COMPILER)
 
 realclean: clean
 

--- a/cola/adaptagrams.i
+++ b/cola/adaptagrams.i
@@ -215,6 +215,12 @@ class ColaException {
 
 %include "libdialect/commontypes.h"
 
+/* pass ownership to C++
+   change ownership of the wrapped Python object to avoid that the interpreter
+   garbage collects it when only a reference is stored in RectanglePtrs
+*/
+%pythonappend Rectangle %{ self.thisown = 0 %}
+
 %template(Chars) std::vector<char>;
 %template(Unsigneds) std::vector<unsigned>;
 %template(Doubles) std::vector<double>;

--- a/cola/autogen.sh
+++ b/cola/autogen.sh
@@ -23,12 +23,14 @@ autoreconf --install --verbose
 # Compile with CXXFLAGS="-std=c++11" when using g++ 14 or newer
 # ./configure CXXFLAGS="-std=c++11"
 
-# Instead, use this line if building for SWIG Java:
+# Instead, use this line if building for SWIG Java or SWIG Python 3:
 # ./configure CPPFLAGS="-DUSE_ASSERT_EXCEPTIONS"
 # Compile with CXXFLAGS="-std=c++11" when using g++ 14 or newer
 # ./configure CXXFLAGS="-std=c++11" CPPFLAGS="-DUSE_ASSERT_EXCEPTIONS"
 
 # Instead, use this line if building for SWIG Python:
+# (this line doesn't seem to work anymore, it's causing problems in particular with
+# libdialect and "-O3 -DNDEBUG")
 # ./configure CXXFLAGS="-O3 -DNDEBUG -arch x86_64 -arch i386" LDFLAGS="-arch x86_64 -arch i386"
 
 # Instead, use this line for development and for debugging the tests:

--- a/cola/swig-python3-setup.py
+++ b/cola/swig-python3-setup.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python
+
+"""
+setup.py file for SWIG example
+"""
+
+from distutils.core import setup, Extension
+# distutils are marked deprecated and will be removed from Python 3.13 and beyond
+# install setuptools
+# from setuptools import setup, Extension
+
+adaptagrams_module = Extension('_adaptagrams',
+                               sources=['adaptagrams_wrap.cxx'],
+                               # extra_compile_args=['-DUSE_ASSERT_EXCEPTIONS','-DSWIG_PYTHON_SILENT_MEMLEAK','-std=gnu++11','-stdlib=libc++'],
+                               extra_compile_args=['-DUSE_ASSERT_EXCEPTIONS','-DSWIG_PYTHON_SILENT_MEMLEAK','-std=c++11'],
+                               include_dirs=['.'],
+                               extra_link_args=['libcola/.libs/libcola.a','libtopology/.libs/libtopology.a', 'libavoid/.libs/libavoid.a','libvpsc/.libs/libvpsc.a','libdialect/.libs/libdialect.a'],
+                               # use this line on MacOS with older versions of the developer tools to avoid linker warning
+                               # '-undefined dynamic_lookup may not work with chained fixups'
+                               # see https://github.com/pybind/pybind11/pull/4301
+                               # extra_link_args=['-Wl,-no_fixup_chains','libcola/.libs/libcola.a','libtopology/.libs/libtopology.a', 'libavoid/.libs/libavoid.a','libvpsc/.libs/libvpsc.a','libdialect/.libs/libdialect.a'],
+                              )
+
+setup (name = 'adaptagrams',
+       version = '0.1',
+       author      = "MArVL",
+       description = """Adaptagrams libraries""",
+       ext_modules = [adaptagrams_module],
+       py_modules = ["adaptagrams"],
+      )


### PR DESCRIPTION
- fixes a problem with ownership of objects and early garbage collection in Python
- autogen.sh can be called with the same line for Java and Python builds
- updates Makefile-swig-python for Python 3
- adds swig-python3-setup.py for the Python 3 extension