### PR TITLE
Fix swig issue, add java sources to jar, do not delete java files when building for Python

### DIFF
--- a/cola/Makefile-swig-java
+++ b/cola/Makefile-swig-java
@@ -56,6 +56,7 @@ adaptagrams: adaptagrams_wrap.o
 jar: swig-worked
 	javac -d java/build/ java/src/org/adaptagrams/*.java
 	jar cf adaptagrams.jar -C java/build/ .
+	jar uf adaptagrams.jar -C java/src/ .
 
 realclean: clean
 

--- a/cola/Makefile-swig-python
+++ b/cola/Makefile-swig-python
@@ -28,7 +28,6 @@ clean: mostlyclean
 mostlyclean:
 	rm -f swig-worked
 	rm -f adaptagrams_wrap.o adaptagrams_wrap.cxx
-	rm -rf java/*
 
 .PHONY: all clean mostlyclean realclean
 

--- a/cola/adaptagrams.i
+++ b/cola/adaptagrams.i
@@ -215,12 +215,6 @@ class ColaException {
 
 %include "libdialect/commontypes.h"
 
-/* pass ownership to C++
-   change ownership of the wrapped Python object to avoid that the interpreter
-   garbage collects it when only a reference is stored in RectanglePtrs
-*/
-%pythonappend Rectangle %{ self.thisown = 0 %}
-
 %template(Chars) std::vector<char>;
 %template(Unsigneds) std::vector<unsigned>;
 %template(Doubles) std::vector<double>;

--- a/cola/libvpsc/rectangle.h
+++ b/cola/libvpsc/rectangle.h
@@ -91,7 +91,12 @@ public:
             bool allowOverlap = false);
     Rectangle(const Rectangle &Other) = default;
     Rectangle();
+// To prevent C++ objects from being destroyed in garbage collected languages
+// when the libraries are called from SWIG, we hide the declarations of the
+// destructors and prevent generation of default destructors.
+#ifndef SWIG
     ~Rectangle() {}
+#endif
 
     bool isValid(void) const;
     Rectangle unionWith(const Rectangle& rhs) const;


### PR DESCRIPTION
Fix a swig issue with garbage collection and freeing memory in C++
- rectangle objects are garbage collected and free by freeAssociatedObjects
- this causes an issue with Swig 3 (it somehow work with Swig 2)
Add java sources to the adaptagrams.jar
Do not delete java files during clean up when building for Python
